### PR TITLE
Fix typos

### DIFF
--- a/index.html
+++ b/index.html
@@ -2099,7 +2099,7 @@ Parts of this work may be from another specification document.  If so, those par
 to express a revised RDF logic as envisoned by <a href="https://www.ihmc.us/groups/phayes/">Pat Hayes</a> in his 2009 ISWC Invited 
 Talk: <a href="https://www.slideshare.net/PatHayes/blogic-iswc-2009-invited-talk">BLOGIC</a>. RDF
 Surfaces logic can be thought as an implementation of <a href="https://en.wikipedia.org/wiki/Charles_Sanders_Peirce">Charles Sanders Peirce</a>'s <a href="http://www.jfsowa.com/peirce/ms514.htm">Existential Graphs</a> in RDF.</p>
-   <p>An RDF surface is a kind of a sheet of paper on which RDF graphs can be written.
+   <p>An RDF surface is a kind of sheet of paper on which RDF graphs can be written.
 All triples that are part of an RDF graph are then on this sheet of paper, including all <a data-link-type="biblio" href="#biblio-uri" title="Uniform Resource Identifier (URI): Generic Syntax">[URI]</a>s, literals and <a href="https://www.w3.org/TR/rdf11-mt/#blank-nodes">Blank nodes</a>. 
 A sheet of paper can contain more than one RDF graph. An RDF graph can’t be split
 over multiple sheets of paper. But, one can copy an RDF graph from one sheet of 
@@ -2123,7 +2123,7 @@ new scratches need to be made.</p>
    </div>
    <div class="example" id="example-0a1c769e">
     <a class="self-link" href="#example-0a1c769e"></a> Two <em>positive surfaces</em>, one with the triple <code>[] a :City</code> (which means <em>"There is something that is a city"</em>),
-and another one with the triple <code>[] a :Cat</code> (which means <em>"There is something is a cat"</em>). 
+and another one with the triple <code>[] a :Cat</code> (which means <em>"There is something that is a cat"</em>). 
     <p><img alt="blank surface" src="images/two_sheets.svg" width="600"></p>
     <p>One can copy these two RDFs graphs to a new surface. This will contain two graphs with
 two blank nodes:</p>
@@ -2140,7 +2140,7 @@ two blank nodes:</p>
 For instance, the sheet of paper in Example 1 is an example of a <strong>positive surface</strong> (we use in this document a paper with a black border as a positive surface). Any
 RDF graph written on this surface is interpreted as logical assertion (true). An empty 
 sheet of positive paper is an empty claim and is treated as a logical tautology (true).</p>
-   <p>When there is there is more than one RDF graph on the surface, then it is a logical conjunction (AND).
+   <p>When there is more than one RDF graph on the surface, then it is a logical conjunction (AND).
 If we interpret the sheets of paper with the black border in the examples above as
 positive surfaces, then  they express:</p>
    <ul>
@@ -2159,8 +2159,8 @@ as existential quantified variables on logical paper.</p>
    <p><strong>Negative surface</strong></p>
    <p>In the same way as a <em>positive surface</em> asserts a logical truth, a <strong>negative surface</strong> asserts a logical negation. The examples below will use a sheet of paper with a red border
 as a negative surface.</p>
-   <p>An empty <em>negative surface</em> on the default positive surface expresses a logical contradicton. When there are one
-or more RDF graphs written on an <em>negative</em> surface they mean the negation of those RDF graphs.</p>
+   <p>An empty <em>negative surface</em> on the default positive surface expresses a logical contradiction. When there are one
+or more RDF graphs written on a <em>negative</em> surface they mean the negation of those RDF graphs.</p>
    <p>A blank node on a negative surface is interpreted as a universal quantified variable. The reason is
 that:</p>
 <pre>NOT(∃ x : P(x)) ⇔ ∀ x : NOT(P(x))
@@ -2208,7 +2208,7 @@ of paper:</p>
    </div>
    <p><strong>First-order logic</strong></p>
    <p>First-order logic can be added to the RDF surfaces by interpreting the blank node as
-an existential quantified variable and using the rule that a universal quantified variable can made from an 
+an existential quantified variable and using the rule that a universal quantified variable can be made from an
 existential quantified variable by placing it in an enclosing negative surface:</p>
 <pre>∀ x : P(x) ⇔ NOT(∃ x : NOT P(x)):
 </pre>
@@ -2307,7 +2307,7 @@ mean alive, or dead, or both alive and dead.
     <a class="self-link" href="#example-85a03cf8"></a> 
     <p><code>:Ghent a :City</code> is a triple on the implicit positive surface. The two nested
 negative surfaces express that for any subject <code>_:S</code> on the positive service
-that is a <code>:City</code>, it implies that <code>_:S</code> needs be be also a <code>:HumanCommunity</code>.</p>
+that is a <code>:City</code>, it implies that <code>_:S</code> also needs to be a <code>:HumanCommunity</code>.</p>
 <pre class="highlight"><c- k>@prefix</c-> <c- nn>ex:</c-> <c- g>&lt;http://example.org/ns#></c-><c- p>.</c->
 <c- k>@prefix</c-> <c- nn>log:</c-> <c- g>&lt;http://www.w3.org/2000/10/swap/log#></c-><c- p>.</c->
 
@@ -2363,9 +2363,9 @@ that is a <code>:City</code>, it implies that <code>_:S</code> needs be be also 
    </table>
    <h2 class="heading settled" data-level="3" id="Surface"><span class="secno">3. </span><span class="content">Surface</span><a class="self-link" href="#Surface"></a></h2>
    <p>Surfaces are written as triples where the <code>subject</code> is a list of zero or more blank nodes.
-The <code>object</code> is a RDF graph or the <code>true</code> or <code>false</code> literal. The blank nodes in the 
+The <code>object</code> is an RDF graph or the <code>true</code> or <code>false</code> literal. The blank nodes in the 
 subject list are treated as marks on the object RDF graph. The <code>predicate</code> specifies 
-the kind of surface. Any kind of surface may be used but the following built-in have 
+the kind of surface. Any kind of surface may be used but the following built-ins have 
 special semantics:</p>
    <table>
     <thead>
@@ -2378,7 +2378,7 @@ special semantics:</p>
       <td>Negative surface claim that any RDF graph in the object position is false. 
    </table>
    <p>A surface can contain zero or more other surfaces. These surfaces are then nested.
-Nested surfaces can share the same <a data-link-type="biblio" href="#biblio-uri" title="Uniform Resource Identifier (URI): Generic Syntax">[URI]</a>-s and literals (by copying the data), 
+Nested surfaces can share the same <a data-link-type="biblio" href="#biblio-uri" title="Uniform Resource Identifier (URI): Generic Syntax">[URI]</a>s and literals (by copying the data), 
 but can’t share blank nodes. Any blank nodes that are written inside a surface 
 (not as subject of an RDF Surface) are to be interpreted as <em>coreferences</em> to the
 blank node graffiti defined on a parent RDF Surface. If no such parent RDF Surface
@@ -2412,7 +2412,7 @@ node graffiti. It is assumed that the default positive surface contains that gra
    </div>
    <h3 class="heading settled" data-level="3.1" id="PositiveSurface"><span class="secno">3.1. </span><span class="content">Positive Surface</span><a class="self-link" href="#PositiveSurface"></a></h3>
    <p>A positive surface is an RDF graph which claims that an RDF Graph on it is true.
-This is the current default interperation of <a href="https://www.w3.org/TR/rdf11-mt/">RDF Semantics</a>.
+This is the current default interpretation of <a href="https://www.w3.org/TR/rdf11-mt/">RDF Semantics</a>.
 When no surfaces are provided, an implicit positive surface is assumed in the RDF document.</p>
    <div class="example" id="example-27b1f9f4">
     <a class="self-link" href="#example-27b1f9f4"></a> The two surfaces below are equal (because a double negation of a statement is the same as claiming the statement is true: positive): 
@@ -2488,7 +2488,7 @@ person that knows Alice".
 <c- p>}</c-> <c- p>.</c->
 </pre>
    </div>
-   <p>In RDF Surfaces an default positive surface is implicitly assumed for each RDF document. On this default positive surface all existential variables are implicitly quantified. Example 20 can be rewritten as:</p>
+   <p>In RDF Surfaces a default positive surface is implicitly assumed for each RDF document. On this default positive surface all existential variables are implicitly quantified. Example 20 can be rewritten as:</p>
    <div class="example" id="example-891ff7ba">
     <a class="self-link" href="#example-891ff7ba"></a> A default positive surface with an implicit <code>_:X</code> existential variable. 
 <pre class="highlight"><c- k>@prefix</c-> <c- nn>:</c-> <c- g>&lt;http://example.org/ns#></c-> <c- p>.</c->
@@ -2498,9 +2498,9 @@ _<c- p>:</c-><c- f>X</c-> <c- b>a</c-> <c- p>:</c-><c- f>Person</c-> <c- p>.</c-
 _<c- p>:</c-><c- f>X</c-> <c- p>:</c-><c- f>knows</c-> <c- p>:</c-><c- f>Alice</c-> <c- p>.</c->
 </pre>
    </div>
-   <p>When a blank node is marked on an odd nested negative surface, then it is interpreted as an universal quantified variable in the scope of the nested surface.</p>
+   <p>When a blank node is marked on an odd nested negative surface, then it is interpreted as a universal quantified variable in the scope of the nested surface.</p>
    <div class="example" id="example-90425235">
-    <a class="self-link" href="#example-90425235"></a> The surface below should be interpreted as : "Every person knows Alice". 
+    <a class="self-link" href="#example-90425235"></a> The surface below should be interpreted as : "Everything is a person and knows Alice". 
     <p>As a logical statement:</p>
 <pre>∀ _:X : _:X a :Person AND _:X :knows :Alice
 </pre>
@@ -2522,7 +2522,7 @@ _<c- p>:</c-><c- f>X</c-> <c- p>:</c-><c- f>knows</c-> <c- p>:</c-><c- f>Alice</
    </div>
    <h3 class="heading settled" data-level="3.2" id="NegativeSurface"><span class="secno">3.2. </span><span class="content">Negative Surface</span><a class="self-link" href="#NegativeSurface"></a></h3>
    <p>A negative surface is an RDF graph which claims that an RDF Graph on it is false. The
-intepretation of the negative surface is the negation of RDF Graph on it.</p>
+interpretation of the negative surface is the negation of RDF Graph on it.</p>
    <p>The semantics of a negative surface is interpreted as a logical falsehood:</p>
    <ul>
     <li data-md>
@@ -2631,7 +2631,7 @@ OR Charly is a person".
 <c- p>}.</c->
 </pre>
    </div>
-   <p>With combinations of AND and NOT other logical truth function can be build. E.g.</p>
+   <p>With combinations of AND and NOT other logical truth function can be built. E.g.</p>
    <ul>
     <li data-md>
      <p>Disjunction: <code>P ∨ Q</code> : <code>NOT( NOT(P) AND NOT(Q))</code></p>


### PR DESCRIPTION
I specifically wanted to fix example 22 where it states that `∀ _:X : _:X a :Person AND _:X :knows :Alice` is equivalent to `"Every person knows Alice"`, while it should be `"Everything is a person and knows Alice"`. Besides that I also fixed some typos that I found. My IDE also wanted to remove all trailing spaces on many lines but I refrained from doing that as I didn't know what the preference would be.